### PR TITLE
Trivial fix: batch maxsize ~off-by-one error

### DIFF
--- a/autoextract/batching.py
+++ b/autoextract/batching.py
@@ -8,7 +8,7 @@ from .constants import API_MAX_BATCH
 
 def build_query(urls: List[str], page_type: str) -> List[Dict]:
     """ Given a list of URLs and page type, return query """
-    if len(urls) >= API_MAX_BATCH:
+    if len(urls) > API_MAX_BATCH:
         raise ValueError("Batch size can't be greater than %s" %
                          API_MAX_BATCH)
     return [{'url': url, 'pageType': page_type} for url in urls]


### PR DESCRIPTION
Noticed that I was not allowed to request 100 URLs, only 99. :)