### PR TITLE
Add --api-endpoint argument to command line utility

### DIFF
--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -24,7 +24,7 @@ logger = logging.getLogger('autoextract')
 
 
 async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
-              api_key=None, max_query_error_retries=0):
+              api_key=None, api_endpoint=None, max_query_error_retries=0):
     agg_stats = AggStats()
     async with create_session() as session:
         result_iter = request_parallel_as_completed(
@@ -33,6 +33,7 @@ async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
             batch_size=batch_size,
             session=session,
             api_key=api_key,
+            endpoint=api_endpoint,
             agg_stats=agg_stats,
             max_query_error_retries=max_query_error_retries
         )
@@ -113,6 +114,8 @@ if __name__ == '__main__':
                    help="Scrapinghub AutoExtract API key. "
                         "You can also set %s environment variable instead "
                         "of using this option." % ENV_VARIABLE)
+    p.add_argument("--api-endpoint",
+                   help="Scrapinghub AutoExtract API endpoint.")
     p.add_argument("--loglevel", "-L", default="INFO",
                    choices=["DEBUG", "INFO", "WARNING", "ERROR"],
                    help="log level")
@@ -141,6 +144,7 @@ if __name__ == '__main__':
                batch_size=args.batch_size,
                stop_on_errors=False,
                api_key=args.api_key,
+               api_endpoint=args.api_endpoint,
                max_query_error_retries=args.max_query_error_retries)
     loop.run_until_complete(coro)
     loop.close()

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -275,7 +275,7 @@ async def request_raw(query: Query,
 def request_parallel_as_completed(query: Query,
                                   api_key: Optional[str] = None,
                                   *,
-                                  endpoint: str = API_ENDPOINT,
+                                  endpoint: Optional[str] = None,
                                   session: Optional[aiohttp.ClientSession] = None,
                                   batch_size=1,
                                   n_conn=1,
@@ -310,6 +310,7 @@ def request_parallel_as_completed(query: Query,
     Use ``max_query_error_retries > 0`` if you want Query-level
     errors to be retried.
     """
+    endpoint = API_ENDPOINT if endpoint is None else endpoint
     sem = asyncio.Semaphore(n_conn)
 
     async def _request(batch_query):


### PR DESCRIPTION
This will make it easier to test AutoExtract queries with alternative API Endpoints (for example staging).