### PR TITLE
Add documentation about Request's extra arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,8 +293,8 @@ or this::
 
     query = [ArticleRequest(url) for url in urls]
 
-There is one difference: ``articleBodyRaw`` parameter is set to ``false``
-by default when Request or its variants are used, while it is ``true``
+There is one difference: ``articleBodyRaw`` parameter is set to ``False``
+by default when Request or its variants are used, while it is ``True``
 by default in the API.
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ To query AutoExtract you need to create a dict with request parameters, e.g.::
 
     {'url': 'http://example.com.foo', 'pageType': 'article'}
 
-To simplify the library usage and avoid typos, scrapinghub-autpextract
+To simplify the library usage and avoid typos, scrapinghub-autoextract
 provides helper classes for constructing these dicts::
 
 * autoextract.Request

--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,31 @@ There is one difference: ``articleBodyRaw`` parameter is set to ``False``
 by default when Request or its variants are used, while it is ``True``
 by default in the API.
 
+You can override API params passing a dictionary with extra data using the
+``extra`` argument. Note that it will overwrite any previous configuration
+made using standard attributes like ``articleBodyRaw`` and ``fullHtml``.
+
+Extra parameters example::
+
+    request = ArticleRequest(
+        url=url,
+        fullHtml=True,
+        extra={
+            "customField": "custom value",
+            "fullHtml": False
+        }
+    )
+
+This will generate a query that looks like this::
+
+    {
+        "url": url,
+        "pageType": "article",
+        "fullHtml": False,  # our extra parameter overrides the previous value
+        "customField": "custom value"  # not a default param but defined even then
+    }
+
+
 Contributing
 ============
 


### PR DESCRIPTION
Briefly showcase what's possible to achieve with the `extra` argument of `Request` and its subclasses.