### PR TITLE
Retry customization

### DIFF
--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -57,6 +57,7 @@ async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
                     pbar.set_postfix_str(str(agg_stats))
         finally:
             pbar.close()
+    logger.debug(agg_stats.summary())
 
 
 def read_input(input_fp, intype, page_type):

--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
                    type=argparse.FileType("r", encoding='utf8'),
                    help="Input file with urls, url per line by default. The "
                         "Format can be changed using `--intype` argument.")
-    p.add_argument("--intype", default="txt", choices=["txt", "jl"], 
+    p.add_argument("--intype", default="txt", choices=["txt", "jl"],
                    help='Type of the input file (default: %(default)s). '
                         'Allowed values are "txt": input should be one '
                         'URL per line, and "jl": input should be a jsonlines '

--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger('autoextract')
 async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
               api_key=None, api_endpoint=None, max_query_error_retries=0):
     agg_stats = AggStats()
-    async with create_session() as session:
+    async with create_session(connection_pool_size=n_conn) as session:
         result_iter = request_parallel_as_completed(
             query=query,
             n_conn=n_conn,

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -139,6 +139,7 @@ async def request_raw(query: Query,
                       max_query_error_retries: int = 0,
                       session: Optional[aiohttp.ClientSession] = None,
                       agg_stats: AggStats = None,
+                      headers: Optional[Dict[str, str]] = None,
                       ) -> Result:
     """ Send a request to Scrapinghub AutoExtract API.
 
@@ -175,6 +176,8 @@ async def request_raw(query: Query,
     ``agg_stats`` argument allows to keep track of various stats; pass an
     ``AggStats`` instance, and it'll be updated.
 
+    Additional ``headers`` for the requests can be provided.
+
     See :func:`request_parallel_as_completed` for a more high-level
     interface to send requests in parallel.
     """
@@ -199,7 +202,7 @@ async def request_raw(query: Query,
 
     post = _post_func(session)
     auth = aiohttp.BasicAuth(get_apikey(api_key))
-    headers = {'User-Agent': user_agent(aiohttp)}
+    headers = {'User-Agent': user_agent(aiohttp), **(headers or {})}
 
     response_stats = []
     start_global = time.perf_counter()

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -202,7 +202,10 @@ async def request_raw(query: Query,
     ``agg_stats`` argument allows to keep track of various stats; pass an
     ``AggStats`` instance, and it'll be updated.
 
-    Additional ``headers`` for the requests can be provided.
+    Additional ``headers`` for the API request can be provided. This headers
+    are included in the request done against the API endpoint: they
+    won't be used in subsequent requests for fetching the URLs provided in
+    the query.
 
     Default retry policy can be customized by providing a
     ``retry_wrapper`` that can be built with a customized

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -125,7 +125,7 @@ class RequestProcessor:
         self._reset()
         for query_result in query_results:
             self._n_query_responses += 1
-            if not "error" in query_result:
+            if "error" not in query_result:
                 self._n_extracted_queries += 1
                 self._n_billable_query_responses += 1
             else:
@@ -161,7 +161,7 @@ async def request_raw(query: Query,
                       session: Optional[aiohttp.ClientSession] = None,
                       agg_stats: AggStats = None,
                       headers: Optional[Dict[str, str]] = None,
-                      retry_wrapper = None
+                      retry_wrapper=None
                       ) -> Result:
     """ Send a request to Scrapinghub AutoExtract API.
 

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -233,6 +233,7 @@ async def request_raw(query: Query,
 
     response_stats = []
     start_global = time.perf_counter()
+    agg_stats.n_input_queries += len(query)
 
     async def request():
         stats = ResponseStats.create(start_global)

--- a/autoextract/aio/errors.py
+++ b/autoextract/aio/errors.py
@@ -57,27 +57,37 @@ class RequestError(ClientResponseError):
                f"headers={self.headers}, body={self.response_content}"
 
 
+_RETRIABLE_ERR_MSGS = [
+    "query timed out",
+    "Downloader error: No response",
+    "Downloader error: http50",
+    "Downloader error: 50",
+    "Downloader error: GlobalTimeoutError",
+    "Proxy error: banned",
+    "Proxy error: internal_error",
+    "Proxy error: nxdomain",
+    "Proxy error: timeout",
+    "Proxy error: ssl_tunnel_error",
+    "Proxy error: msgtimeout",
+    "Proxy error: econnrefused",
+]
+
+
+_RETRIABLE_ERR_MSGS_RE = re.compile(
+    "|".join(re.escape(msg) for msg in _RETRIABLE_ERR_MSGS), re.IGNORECASE
+)
+
+
+def is_retriable_error_msg(msg: Optional[str]) -> bool:
+    """True if the error is one of those that could benefit from a retry"""
+    msg = msg or ""
+    return bool(_RETRIABLE_ERR_MSGS_RE.search(msg))
+
+
 class _QueryError(Exception):
     """ Exception which is raised when a Query-level error is returned.
     https://doc.scrapinghub.com/autoextract.html#query-level
     """
-
-    RETRIABLE_MESSAGES = {
-        message.lower().strip()
-        for message in [
-            "query timed out",
-            "Downloader error: No response (network5)",
-            "Downloader error: http50",
-            "Downloader error: GlobalTimeoutError",
-            "Proxy error: banned",
-            "Proxy error: internal_error",
-            "Proxy error: nxdomain",
-            "Proxy error: timeout",
-            "Proxy error: ssl_tunnel_error",
-            "Proxy error: msgtimeout",
-            "Proxy error: econnrefused",
-        ]
-    }
 
     def __init__(self, query: dict, message: str, max_retries: int = 0):
         self.query = query
@@ -98,14 +108,12 @@ class _QueryError(Exception):
     def retriable(self) -> bool:
         if self.domain_occupied:
             return True
-
-        return self.message.lower().strip() in self.RETRIABLE_MESSAGES
+        return is_retriable_error_msg(self.message)
 
     @property
     def retry_seconds(self) -> float:
         if self.domain_occupied:
             return self.domain_occupied.retry_seconds
-
         return 0.0
 
 
@@ -114,3 +122,40 @@ class QueryRetryError(RetryError):
     timeouts when retrying Query-level errors (see :class:``._QueryError``).
     """
     pass
+
+
+# Based on https://doc.scrapinghub.com/autoextract.html#reference
+_NON_BILLABLE_ERR_MSGS = [
+    "malformed url",
+    "URL cannot be longer than",
+    "non-HTTP schemas are not allowed",
+    "Extraction not permitted for this URL",
+]
+
+
+_NON_BILLABLE_ERR_MSGS_RE = re.compile(
+    "|".join(re.escape(msg) for msg in _NON_BILLABLE_ERR_MSGS), re.IGNORECASE
+)
+
+
+def is_billable_error_msg(msg: Optional[str]) -> bool:
+    """
+    Return true if the error message is billable. Based on
+    https://doc.scrapinghub.com/autoextract.html#reference
+
+    >>> is_billable_error_msg(None)
+    True
+    >>> is_billable_error_msg("")
+    True
+    >>> is_billable_error_msg(" URL cannot be longer than 4096 UTF-16 characters ")
+    False
+    >>> is_billable_error_msg(" malformed url ")
+    False
+    >>> is_billable_error_msg("Domain example.com is occupied, please retry in 23.5 seconds")
+    False
+    """
+    msg = msg or ""
+    is_domain_ocupied = bool(DomainOccupied.from_message(msg))
+    is_no_billable = (_NON_BILLABLE_ERR_MSGS_RE.search(msg) or
+                      is_domain_ocupied)
+    return not is_no_billable

--- a/autoextract/aio/retry.py
+++ b/autoextract/aio/retry.py
@@ -106,15 +106,6 @@ class RetryFactory:
     server_error_stop = stop_after_delay(15 * 60)
     retryable_query_error_stop = stop_after_delay(15 * 60)
 
-    def __init__(self, **kwargs):
-        mutable_attributes = {attrib for attrib in dir(self)
-                              if not attrib.startswith("_")}
-        for k, v in kwargs:
-            if not k in mutable_attributes:
-                raise TypeError(f"Attribute {k} is invalid. Any of "
-                                f"{mutable_attributes} was expected")
-            setattr(self, k, v)
-
     def wait(self, retry_state: RetryCallState) -> float:
         exc = retry_state.outcome.exception()
         if _is_throttling_error(exc):

--- a/autoextract/aio/retry.py
+++ b/autoextract/aio/retry.py
@@ -20,7 +20,7 @@ from tenacity import (
     RetryError,
     retry,
     before_sleep_log,
-    after_log,
+    after_log, AsyncRetrying,
 )
 from tenacity.stop import stop_never
 
@@ -144,8 +144,8 @@ class RetryFactory:
     def after(self, retry_state: RetryCallState):
         return after_log(logger, logging.DEBUG)
 
-    def build(self):
-        return retry(
+    def build(self) -> AsyncRetrying:
+        return AsyncRetrying(
             wait=self.wait,
             retry=self.retry_condition,
             stop=self.stop,
@@ -155,4 +155,4 @@ class RetryFactory:
         )
 
 
-autoextract_retry = RetryFactory().build()
+autoextract_retrying: AsyncRetrying = RetryFactory().build()

--- a/autoextract/aio/retry.py
+++ b/autoextract/aio/retry.py
@@ -76,10 +76,10 @@ class RetryFactory:
     Build custom retry configuration
     """
     retry_condition = (
-            retry_if_exception(_is_throttling_error) |
-            retry_if_exception(_is_network_error) |
-            retry_if_exception(_is_server_error) |
-            retry_if_exception(_is_retriable_query_error)
+        retry_if_exception(_is_throttling_error) |
+        retry_if_exception(_is_network_error) |
+        retry_if_exception(_is_server_error) |
+        retry_if_exception(_is_retriable_query_error)
     )
     # throttling
     throttling_wait = wait_chain(

--- a/autoextract/stats.py
+++ b/autoextract/stats.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import textwrap
 from typing import Optional
 import functools
 import time
@@ -48,19 +47,24 @@ class AggStats:
         )
 
     def summary(self):
-        return textwrap.dedent(f"""
-            Summary
-            -------
-            Mean connection time:    {self.time_connect_stats.mean():0.2f}
-            Mean response time:      {self.time_total_stats.mean():0.2f}
-            Throttle ratio:          {self.throttle_ratio():0.1%}
-            Attempts:                {self.n_attempts}
-            Errors:                  {self.error_ratio():0.1%}, fatal: {self.n_fatal_errors}, non fatal: {self.n_errors - self.n_fatal_errors}
-            Successful URLs:         {self.n_extracted_queries} of {self.n_input_queries}
-            Success ratio:           {self.success_ratio():0.1%}
-            Billable query responses: {self.n_billable_query_responses} of {self.n_query_responses} 
-        """)
-
+        return (
+            "\n" +
+            "Summary\n" +
+            "-------\n" +
+            "Mean connection time:     {:0.2f}\n".format(self.time_connect_stats.mean()) +
+            "Mean response time:       {:0.2f}\n".format(self.time_total_stats.mean()) +
+            "Throttle ratio:           {:0.1%}\n".format(self.throttle_ratio()) +
+            "Attempts:                 {}\n".format(self.n_attempts) +
+            "Errors:                   {:0.1%}, fatal: {}, non fatal: {}\n".format(
+                self.error_ratio(),
+                self.n_fatal_errors,
+                self.n_errors - self.n_fatal_errors) +
+            "Successful URLs:          {} of {}\n".format(
+                self.n_extracted_queries, self.n_input_queries) +
+            "Success ratio:            {:0.1%}\n".format(self.success_ratio()) +
+            "Billable query responses: {} of {}\n".format(
+                self.n_billable_query_responses, self.n_query_responses)
+        )
 
     @zero_on_division_error
     def throttle_ratio(self):

--- a/tests/test_aio/test_errors.py
+++ b/tests/test_aio/test_errors.py
@@ -19,12 +19,13 @@ def get_query_error(message):
 
 
 @pytest.mark.parametrize("message, retriable", (
-        ("Downloader error: http404", False),
-        ("query timed out", True),
+        (" downloader error: http404 bla", False),
+        ("ey query timed out ", True),
         ("Downloader error: No response (network5)", True),
         ("Downloader error: http50", True),
+        ("Downloader error: http504", True),
         ("Downloader error: GlobalTimeoutError", True),
-        ("Proxy error: banned", True),
+        ("Proxy error: banned. Because bla", True),
         ("Proxy error: internal_error", True),
         ("Proxy error: nxdomain", True),
         ("Proxy error: timeout", True),

--- a/tests/test_aio/test_errors.py
+++ b/tests/test_aio/test_errors.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import json
+
 import pytest
 
-from autoextract.aio.errors import _QueryError
+from autoextract.aio.errors import _QueryError, ACCOUNT_DISABLED_ERROR_TYPE, \
+    RequestError
 
 
 def get_query_error(message):
@@ -78,3 +81,25 @@ def test_invalid_domain_occupied_query_error(message):
     exc = _QueryError.from_query_result(query_error)
     assert exc.domain_occupied is None
     assert exc.retry_seconds == 0.0
+
+
+@pytest.mark.parametrize(
+    ["error_data", "expected"],
+    [
+        [
+            {"type": ACCOUNT_DISABLED_ERROR_TYPE},
+            {"type": ACCOUNT_DISABLED_ERROR_TYPE}
+        ],
+        [["A list is not right"], {}],
+        [b"wrong Utf-8 \234", {}],
+        [None, {}],
+    ],
+)
+def test_request_error_data(error_data,
+                            expected):
+    if not isinstance(error_data, bytes):
+        error_data = json.dumps(error_data).encode("utf-8")
+    re = RequestError(request_info=None,
+                      history=None,
+                      response_content=error_data)
+    assert re.error_data() == expected

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,13 @@
+import time
+
+from autoextract.stats import AggStats, ResponseStats
+
+
+def test_agg_stats():
+    stats = AggStats()
+    stats.time_connect_stats.push(4)
+    rs = ResponseStats.create(time.perf_counter())
+    rs.record_read(stats)
+    rs.record_connected(stats)
+    assert isinstance(stats.summary(), str)
+    assert isinstance(str(stats), str)


### PR DESCRIPTION
In this PR:
* Customization of headers in `request_raw`
* Customization of retry policy in `request_raw`
* Improved stats (counting billable responses, more meaningful success ratio)
* Fix a bug with retry messages (some of them were missing)