### PR TITLE
Reraise last exception in retries instead of RetryError

### DIFF
--- a/autoextract/aio/errors.py
+++ b/autoextract/aio/errors.py
@@ -6,7 +6,6 @@ from json import JSONDecodeError
 from typing import Optional
 
 from aiohttp import ClientResponseError
-from tenacity import RetryError
 
 logger = logging.getLogger(__name__)
 
@@ -138,13 +137,6 @@ class _QueryError(Exception):
         if self.domain_occupied:
             return self.domain_occupied.retry_seconds
         return 0.0
-
-
-class QueryRetryError(RetryError):
-    """This exception is raised when Tenacity reaches the max retry count or
-    timeouts when retrying Query-level errors (see :class:``._QueryError``).
-    """
-    pass
 
 
 # Based on https://doc.scrapinghub.com/autoextract.html#reference


### PR DESCRIPTION
It makes no sense to raise tenacity.RetryError:
* It exposes an internal about retrials
* It makes more difficult error handling by the client
* It makes the code more complex
* Behaviour is different when retries are disabled

Instead, the last exception obtained in the last attempt is reraised.
This way the client will only face with meaningful exceptions
(e.g. RequestError, or other connection errors). The number
of attempts is returned in the stats, so this is not a problem.