### PR TITLE
Attempts must be max_retries + 1

### DIFF
--- a/autoextract/aio/retry.py
+++ b/autoextract/aio/retry.py
@@ -123,7 +123,7 @@ class RetryFactory:
         elif _is_retriable_query_error(exc):
             return (
                 self.retryable_query_error_stop |
-                stop_after_attempt(exc.max_retries)
+                stop_after_attempt(exc.max_retries + 1)
             )(retry_state)
         else:
             raise RuntimeError("Invalid retry state exception: %s" % exc)


### PR DESCRIPTION
When the user sets the argument `max_query_error_retries` he
is defining how many retries to do in case of a failure.
0 means no retries at all (so 1 attempt), 1 means one
retry (so up to 2 attempts) and so on. Retrying module
was not being configured properly then.